### PR TITLE
Add option to change eSCO Transport Unit Size

### DIFF
--- a/device/src/esco_parameters.cc
+++ b/device/src/esco_parameters.cc
@@ -20,7 +20,9 @@
 
 #include "device/include/esco_parameters.h"
 
-static const enh_esco_params_t default_esco_parameters[ESCO_NUM_CODECS] = {
+#include <cutils/properties.h>
+
+static enh_esco_params_t default_esco_parameters[ESCO_NUM_CODECS] = {
     // CVSD
     {.transmit_bandwidth = TXRX_64KBITS_RATE,
      .receive_bandwidth = TXRX_64KBITS_RATE,
@@ -143,5 +145,10 @@ enh_esco_params_t esco_parameters_for_codec(esco_codec_t codec) {
   CHECK(codec >= 0) << "codec index " << (int)codec << "< 0";
   CHECK(codec < ESCO_NUM_CODECS) << "codec index " << (int)codec << " > "
                                  << ESCO_NUM_CODECS;
+  int escoTransportUnitSize = property_get_int32("persist.sys.bt.esco_transport_unit_size", 0);
+  if(escoTransportUnitSize) {
+    default_esco_parameters[codec].input_transport_unit_size = escoTransportUnitSize;
+    default_esco_parameters[codec].output_transport_unit_size = escoTransportUnitSize;
+  }
   return default_esco_parameters[codec];
 }


### PR DESCRIPTION
Fixes Bluetooth calls on some Samsung devices if set to 16.
It's still unknown if other Treble devices need other values so it's preferred to leave this able to be configured with another integer.
This applies to mSBC T2, T1 and CVSD codecs